### PR TITLE
feat(api): implement DELETE endpoint to delete user listing

### DIFF
--- a/app/api/listings/[listingId]/route.ts
+++ b/app/api/listings/[listingId]/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import getCurrentUser from "@/app/actions/getCurrentUser";
+import prisma from "@/app/libs/prismadb";
+
+interface IParams {
+  listingId?: string;
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: IParams }
+) {
+  const currentUser = await getCurrentUser();
+
+  if (!currentUser) {
+    return NextResponse.error();
+  }
+
+  const { listingId } = params;
+
+  if (!listingId || typeof listingId !== "string") {
+    throw new Error("Invalid ID");
+  }
+
+  const listing = await prisma.listing.deleteMany({
+    where: {
+      id: listingId,
+      userId: currentUser.id,
+    },
+  });
+
+  return NextResponse.json(listing);
+}


### PR DESCRIPTION
Added a DELETE endpoint to handle the deletion of user listings. The endpoint verifies the user's authentication status using getCurrentUser function. If the user is not authenticated, it returns an error response. The endpoint expects a valid listingId parameter and checks if it's a string. It then uses prisma to delete the listing associated with the provided listingId and the current user's id. Finally, it returns a JSON response with the deleted listing.