### PR TITLE
refactor(search): utilize useSearchModal hook in Search component

### DIFF
--- a/app/components/navbar/Search.tsx
+++ b/app/components/navbar/Search.tsx
@@ -2,9 +2,14 @@
 
 import { BiSearch } from "react-icons/bi";
 
+import useSearchModal from "@/app/hooks/useSearchModal";
+
 const Search = () => {
+  const searchModal = useSearchModal();
+
   return (
     <div
+      onClick={searchModal.onOpen}
       className="
             border-[1px] 
             w-full 


### PR DESCRIPTION
Refactored the Search component to utilize the useSearchModal hook from "@/app/hooks/useSearchModal" for managing the search modal state. Now, clicking on the search component triggers the onOpen function of the search modal, allowing for consistent state management.