### PR TITLE
fix(modal): fix secondary action behavior in SearchModal

### DIFF
--- a/app/components/modals/SearchModal.tsx
+++ b/app/components/modals/SearchModal.tsx
@@ -154,9 +154,11 @@ const SearchModal = () => {
     <Modal
       isOpen={searchModal.isOpen}
       onClose={searchModal.onClose}
-      onSubmit={searchModal.onOpen}
+      onSubmit={onSubmit}
       title="Filters"
-      actionLabel="Search"
+      actionLabel={actionLabel}
+      secondaryActionLabel={secondaryActionLabel}
+      secondaryAction={step === STEPS.LOCATION ? undefined : onBack}
       body={bodyContent}
     />
   );


### PR DESCRIPTION
Updated the SearchModal component to fix the behavior of the secondary action button. Now, the secondary action button only appears as "Back" when the step is not in the location selection step. This ensures proper navigation within the modal, allowing users to go back to the previous step without unnecessary buttons in the initial step. This fix enhances the overall usability and consistency of the modal interface.